### PR TITLE
Fixed global matrix generation for Transform

### DIFF
--- a/ECS/Components/Transform.cs
+++ b/ECS/Components/Transform.cs
@@ -46,7 +46,7 @@ namespace Frozen.ECS.Components
 
 		private void UpdateMatrix()
 		{
-			this.transformMatrix = Matrix.CreateRotationZ(this.rotation) * Matrix.CreateTranslation(this.position) * Matrix.CreateScale(this.scale);
+			this.transformMatrix = Matrix.CreateScale(this.scale) * Matrix.CreateRotationZ(this.rotation) * Matrix.CreateTranslation(this.position);
 		}
 
 		public void MoveBy(Vector2 movement)


### PR DESCRIPTION
This fixes the global matrix generation; operations were in the wrong order causing scale to influence the local position